### PR TITLE
Fix plugin for OSX and X11 platforms

### DIFF
--- a/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
+++ b/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
@@ -70,14 +70,16 @@ func flags_to_namelist(val:int,namelist:Array):
 			result.append(namelist[i].to_upper())
 	return result
 func get_cache_dir():
-	if OS.get_name()=="Windows":
-		return "%TEMP%\\Godot\\"
-	elif OS.get_name()=="OSX":
-		return "~/Library/Caches/Godot/"
-	elif OS.get_name()=="X11":
-		return "~/.cache/godot/"
+	match OS.get_name():
+		"Windows":
+			return "%TEMP%\\Godot\\"
+		"OSX":
+			return "~/Library/Caches/Godot/"
+		"X11":
+			return "~/.cache/godot/"
+
 var addon_cache_dir = "res://addons/blender_importer/cache/"
-		
+
 func import(source_file, save_path, options, platform_variants, gen_files):
 	var file = File.new()
 	var dir = Directory.new()
@@ -85,7 +87,7 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 		printerr("Failed to read blend file")
 		return FAILED
 	file.close()
-	var os_blenderexe = globalize_workaround("C:\\Program Files\\Blender Foundation\\Blender 2.83\\blender.exe")
+	var os_blenderexe = globalize_workaround(ProjectSettings.get_setting("blender/path"))
 	var os_sourcefile = globalize_workaround(ProjectSettings.globalize_path(source_file))
 	
 	var filename = addon_cache_dir + save_path.get_file() + ".glb"

--- a/addons/blender_importer/blender_plugin.gd
+++ b/addons/blender_importer/blender_plugin.gd
@@ -4,13 +4,26 @@ extends EditorPlugin
 var import_plugins = []
 
 func _enter_tree():
-	ProjectSettings.set("blender/path", "C:\\Program Files\\Blender Foundation\\Blender 2.83\\blender.exe")
+	if !ProjectSettings.has_setting("blender/path"):
+		# Initial load, try some sane default paths for each OS
+		var path = null
+
+		match OS.get_name():
+			"Windows":
+				path = "C:\\Program Files\\Blender Foundation\\Blender 2.83\\blender.exe"
+			"OSX":
+				path = "/Applications/Blender.app/Contents/MacOS/Blender"
+			"X11":
+				path = "/usr/bin/blender"
+
+		ProjectSettings.set_setting("blender/path", path)
+
 	var property_info = {
 		"name": "blender/path",
 		"type": TYPE_STRING,
 		"hint": PROPERTY_HINT_GLOBAL_FILE,
 		"hint_string": "*.exe"
-	}	
+	}
 	ProjectSettings.add_property_info(property_info)
 	
 	for P in [


### PR DESCRIPTION
Uses "blender/path" from ProjectSettings, and prevents the path getting overwritten every time the plugin is loaded