### PR TITLE
Cleanup, File Selector improvements and Import cache use

### DIFF
--- a/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
+++ b/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
@@ -1,13 +1,8 @@
 tool
 extends EditorImportPlugin
+
 enum Presets {GLTF_GLB}
-class PySet:
-	extends Object
-	var value:Array
-func newPySet(val:Array):
-	var ins = PySet.new()
-	ins.value = val
-	return ins
+
 func get_importer_name():
 	return "blender.gltf"
 
@@ -27,58 +22,19 @@ func get_preset_count():
 	return 1
 
 func get_preset_name(i):
-	if i==Presets.GLTF_GLB:
+	if i == Presets.GLTF_GLB:
 		return "Blender Gltf exporter"
 func get_import_options(i):
-	if i==Presets.GLTF_GLB:
+	if i == Presets.GLTF_GLB:
 		return [ ]
-func quote(val):
-	return '"%s"'%val
-func escape_quotes(val:String):
-	return val.replace("\\","\\\\").replace('"','\\"').replace("'","\\'")
-func gdval2py(v):
-	if v is String:
-		return '"%s"'%v
-	elif v is Array:
-		var r = PoolStringArray([])
-		for i in v:
-			r.append(gdval2py(i))
-		return '[%s]'%r.join(", ")
-	elif v is Dictionary:
-		var r = PoolStringArray()
-		for ik in v.keys():
-			var iv = v[ik]
-			r.append("\"%s\":%s"%[ik,gdval2py(iv)])
-		return "{%s}"%r.join(", ")
-	elif v is PySet:
-		var r = PoolStringArray([])
-		for i in v.value:
-			r.append(gdval2py(i))
-		return '{%s}'%r.join(", ")
-	else:
-		return String(v)
 
-func globalize_workaround(val:String):
-	if OS.get_name()=="Windows":
+func globalize_workaround(val: String):
+	if OS.get_name() == "Windows":
+		# To run binaries with OS.execute on Windows, the Unix directory separator should be changed
+		# to the Windows separator
 		return val.replace("/","\\")
 	else:
 		return val
-func flags_to_namelist(val:int,namelist:Array):
-	var result = []
-	for i in namelist.size():
-		if (1<<i & val)>0:
-			result.append(namelist[i].to_upper())
-	return result
-func get_cache_dir():
-	match OS.get_name():
-		"Windows":
-			return "%TEMP%\\Godot\\"
-		"OSX":
-			return "~/Library/Caches/Godot/"
-		"X11":
-			return "~/.cache/godot/"
-
-var addon_cache_dir = "res://addons/blender_importer/cache/"
 
 func import(source_file, save_path, options, platform_variants, gen_files):
 	var file = File.new()

--- a/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
+++ b/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
@@ -3,6 +3,11 @@ extends EditorImportPlugin
 
 enum Presets {GLTF_GLB}
 
+var editor_settings: EditorSettings
+
+func _init(editor_settings: EditorSettings) -> void:
+	self.editor_settings = editor_settings
+
 func get_importer_name():
 	return "blender.gltf"
 
@@ -47,7 +52,7 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 	file.close()
 
 	# Get the global path to the Blender executable, blend file and the destination file
-	var os_blenderexe = globalize_workaround(ProjectSettings.get_setting("blender/path"))
+	var os_blenderexe = globalize_workaround(editor_settings.get_setting("blender/path"))
 	var os_sourcefile = globalize_workaround(ProjectSettings.globalize_path(source_file))
 	var os_filename = globalize_workaround(ProjectSettings.globalize_path(save_path))
 

--- a/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
+++ b/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
@@ -7,7 +7,7 @@ func get_importer_name():
 	return "blender.gltf"
 
 func get_visible_name():
-	return "Blender GLTF XImporter"
+	return "Blender glTF XImporter"
 
 func get_recognized_extensions():
 	return ["blend"]
@@ -23,7 +23,7 @@ func get_preset_count():
 
 func get_preset_name(i):
 	if i == Presets.GLTF_GLB:
-		return "Blender Gltf exporter"
+		return "glTF Binary (glb)"
 func get_import_options(i):
 	if i == Presets.GLTF_GLB:
 		return [ ]

--- a/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
+++ b/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
@@ -51,6 +51,10 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 	var os_sourcefile = globalize_workaround(ProjectSettings.globalize_path(source_file))
 	var os_filename = globalize_workaround(ProjectSettings.globalize_path(save_path))
 
+	# Add the path to the actual executable for macOS
+	if OS.get_name() == "OSX":
+		os_blenderexe += "/Contents/MacOS/Blender"
+
 	# Build the python expression for running the glTF exporter
 	var os_pyexpr = "import bpy,sys;print(' '.join(sys.argv));bpy.ops.export_scene.gltf(filepath=r'%s')"%os_filename
 

--- a/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
+++ b/addons/blender_importer/blender_gltf_exporter_import_plugin.gd
@@ -70,14 +70,16 @@ func flags_to_namelist(val:int,namelist:Array):
 			result.append(namelist[i].to_upper())
 	return result
 func get_cache_dir():
-	if OS.get_name()=="Windows":
-		return "%TEMP%\\Godot\\"
-	elif OS.get_name()=="OSX":
-		return "~/Library/Caches/Godot/"
-	elif OS.get_name()=="X11":
-		return "~/.cache/godot/"
+	match OS.get_name():
+		"Windows":
+			return "%TEMP%\\Godot\\"
+		"OSX":
+			return "~/Library/Caches/Godot/"
+		"X11":
+			return "~/.cache/godot/"
+
 var addon_cache_dir = "res://addons/blender_importer/cache/"
-		
+
 func import(source_file, save_path, options, platform_variants, gen_files):
 	var file = File.new()
 	var dir = Directory.new()
@@ -85,7 +87,7 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 		printerr("Failed to read blend file")
 		return FAILED
 	file.close()
-	var os_blenderexe = globalize_workaround("C:\\Program Files\\Blender Foundation\\Blender 2.83\\blender.exe")
+	var os_blenderexe = globalize_workaround(ProjectSettings.get_setting("blender/path"))
 	var os_sourcefile = globalize_workaround(ProjectSettings.globalize_path(source_file))
 	
 	var filename = addon_cache_dir + save_path.get_file() + ".glb"

--- a/addons/blender_importer/blender_plugin.gd
+++ b/addons/blender_importer/blender_plugin.gd
@@ -4,26 +4,34 @@ extends EditorPlugin
 var import_plugins = []
 
 func _enter_tree():
-	if !ProjectSettings.has_setting("blender/path"):
-		# Initial load, try some sane default paths for each OS
-		var path = null
-
-		match OS.get_name():
-			"Windows":
-				path = "C:\\Program Files\\Blender Foundation\\Blender 2.83\\blender.exe"
-			"OSX":
-				path = "/Applications/Blender.app/Contents/MacOS/Blender"
-			"X11":
-				path = "/usr/bin/blender"
-
-		ProjectSettings.set_setting("blender/path", path)
-
+	var path = null
 	var property_info = {
 		"name": "blender/path",
 		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_GLOBAL_FILE,
-		"hint_string": "*.exe"
 	}
+	
+	# Set some sane default paths for each OS and their File Selectors
+	match OS.get_name():
+		"Windows":
+			path = "C:\\Program Files\\Blender Foundation\\Blender 2.83\\blender.exe"
+
+			property_info["hint"] = PROPERTY_HINT_GLOBAL_FILE
+			property_info["hint_string"] = "*.exe"
+		"OSX":
+			path = "/Applications/Blender.app"
+
+			property_info["hint"] = PROPERTY_HINT_GLOBAL_DIR
+			property_info["hint_string"] = "*.app"
+		"X11":
+			path = "/usr/bin/blender"
+			
+			property_info["hint"] = PROPERTY_HINT_GLOBAL_FILE
+			property_info["hint_string"] = "*"
+
+	# If there isn't a property for the path yet, use the defaults
+	if !ProjectSettings.has_setting("blender/path"):
+		ProjectSettings.set_setting("blender/path", path)
+
 	ProjectSettings.add_property_info(property_info)
 	
 	for P in [

--- a/addons/blender_importer/blender_plugin.gd
+++ b/addons/blender_importer/blender_plugin.gd
@@ -29,7 +29,7 @@ func _enter_tree():
 	for P in [
 #		preload("res://addons/blender_importer/blender_escn_exporter_import_plugin.gd"),
 		preload("res://addons/blender_importer/blender_gltf_exporter_import_plugin.gd"),
-		]:
+	]:
 		var p = P.new()
 		add_import_plugin(p)
 		import_plugins.append(p)

--- a/addons/blender_importer/blender_plugin.gd
+++ b/addons/blender_importer/blender_plugin.gd
@@ -4,13 +4,26 @@ extends EditorPlugin
 var import_plugins = []
 
 func _enter_tree():
-	ProjectSettings.set("blender/path", "C:\\Program Files\\Blender Foundation\\Blender 2.83\\blender.exe")
+	if !ProjectSettings.has_setting("blender/path"):
+		# Initial load, try some sane default paths for each OS
+		var path = null
+
+		match OS.get_name():
+			"Windows":
+				path = "C:\\Program Files\\Blender Foundation\\Blender 2.83\\blender.exe"
+			"OSX":
+				path = "/Applications/Blender.app/Contents/MacOS/Blender"
+			"X11":
+				path = "/usr/bin/blender"
+
+		ProjectSettings.set_setting("blender/path", path)
+
 	var property_info = {
 		"name": "blender/path",
 		"type": TYPE_STRING,
 		"hint": PROPERTY_HINT_GLOBAL_FILE,
 		"hint_string": "*.exe"
-	}	
+	}
 	ProjectSettings.add_property_info(property_info)
 	
 	for P in [

--- a/addons/blender_importer/blender_plugin.gd
+++ b/addons/blender_importer/blender_plugin.gd
@@ -28,17 +28,19 @@ func _enter_tree():
 			property_info["hint"] = PROPERTY_HINT_GLOBAL_FILE
 			property_info["hint_string"] = "*"
 
-	# If there isn't a property for the path yet, use the defaults
-	if !ProjectSettings.has_setting("blender/path"):
-		ProjectSettings.set_setting("blender/path", path)
+	var editor_settings := get_editor_interface().get_editor_settings()
 
-	ProjectSettings.add_property_info(property_info)
+	# If there isn't a property for the path yet, use the defaults
+	if !editor_settings.has_setting("blender/path"):
+		editor_settings.set_setting("blender/path", path)
+
+	editor_settings.add_property_info(property_info)
 	
 	for P in [
 #		preload("res://addons/blender_importer/blender_escn_exporter_import_plugin.gd"),
 		preload("res://addons/blender_importer/blender_gltf_exporter_import_plugin.gd"),
 	]:
-		var p = P.new()
+		var p = P.new(editor_settings)
 		add_import_plugin(p)
 		import_plugins.append(p)
 


### PR DESCRIPTION
Some cleanup to remove unused code in the importer script and change formatting

The Blender executable path is now taken from the Editor Settings, and updated to fit well with macOS and Linux/BSD by changing the filters used. I've tested it for Linux, macOS and Windows _should_ work but I couldn't test it

The plugin now no longer requires a separate cache directory as it can now store the GLB and convert it to an SCN within `res://.import`. This is thanks to [an Editor API function that lets an importer call the inbuilt Scene importer directly](https://github.com/godotengine/godot/blob/a36c084f753dbafb2000f0e404cf69e28efa23ad/editor/import/resource_importer_scene.cpp#L89)

This supersedes #1 